### PR TITLE
fix: use reasonable amount of gas

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -202,17 +202,17 @@ export function crossContract(): void {
       context.contractName,               // contract account name
       "crossContractFailure",       // contract method name
       new Uint8Array(0),           // serialized contract method arguments encoded as Uint8Array
-      400000000000000,                      // gas attached to the call
+      100000000000000,                      // gas attached to the call
       u128.Zero                           // attached deposit to be sent with the call
-  )
+  );
 
-  logging.log(context.contractName)
+  logging.log(context.contractName);
 
   let callbackPromise = promise.then(
       context.contractName,
       "triggerAssert",
       new Uint8Array(0),
-      200000000000000,
+      100000000000000,
       u128.Zero
   );
 


### PR DESCRIPTION
The amount of gas used in `crossContract` before exceeds the prepaid gas limit and therefore causes nearlib tests to fail.