### PR TITLE
chore: remove assemblyscript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     },
     "types": "assembly/index.ts",
     "devDependencies": {
-        "assemblyscript": "^0.12.3",
         "in-publish": "^2.0.1",
         "near-sdk-as": "^0.4.2",
         "near-shell": "^0.24.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,14 +326,6 @@ assemblyscript@0.10.0:
     binaryen "93.0.0-nightly.20200514"
     long "^4.0.0"
 
-assemblyscript@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.12.3.tgz#f705dd0101ddeb40088d9ec3f9c2f20fe88d74eb"
-  integrity sha512-cdIbbP1Xoduw5nt3C7o2jYTQCrcPAnqoASgBMmOOcf/UY4k+xYJbV5eHwMwVSKZXAI74PUSwfxYjLF7L7CWA9g==
-  dependencies:
-    binaryen "93.0.0-nightly.20200609"
-    long "^4.0.0"
-
 axios@^0.19.0:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
@@ -374,11 +366,6 @@ binaryen@93.0.0-nightly.20200514:
   version "93.0.0-nightly.20200514"
   resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-93.0.0-nightly.20200514.tgz#af498b5d9f8169254fb0cd385061d94ba9b27b1d"
   integrity sha512-SRRItmNvhRVfoWWbRloO4i8IqkKH8rZ7/0QWRgLpM3umupK8gBpo9MY7Zp3pDysRSp+rVoqxvM5x4tFyCSa9zw==
-
-binaryen@93.0.0-nightly.20200609:
-  version "93.0.0-nightly.20200609"
-  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-93.0.0-nightly.20200609.tgz#e7c9211911c0cff94b8682e895e4de630f110cd5"
-  integrity sha512-CIaeav05u+fWRN2h1ecwIoSaOF/Mk6U85M/G6eg1nOHAXYYmOuh9TztF9Fu8krRWnl98J3W+VfDClApMV5zCtw==
 
 bindings@^1.4.0, bindings@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
This is now included via near-sdk-as, and does not need to be explicitly included in this project's dependencies